### PR TITLE
Feature/add workflow

### DIFF
--- a/.github/workflows/ghost-inspector.yml
+++ b/.github/workflows/ghost-inspector.yml
@@ -23,9 +23,11 @@ jobs:
           response=$(curl "https://api.ghostinspector.com/v1/suites/${{ secrets.SUITE_ID }}/results/?apiKey=${{ secrets.API_KEY }}&count=1")
           name=$(jq '.data[0].name' <<< $response )
           result=$(jq '.data[0].passing' <<< $response)
+          failingCount=$(jq '.data[0].countFailing' <<< $response)
+          passingCount=$(jq '.data[0].countPassing' <<< $response)
           if [[ $result == 'true' ]]; then
-            echo "Suite ${name} passing"
+            echo "Suite ${name} passing: ${passingCount} passed, 0 failed"
             exit 0
           fi
-          echo "Suite ${name} failing"
+          echo "Suite ${name} failing: ${passingCount} passed, ${failingCount} failed"
           exit 1

--- a/.github/workflows/ghost-inspector.yml
+++ b/.github/workflows/ghost-inspector.yml
@@ -1,0 +1,31 @@
+name: Run Ghost Inspector test suite
+
+on: 
+  workflow_call:
+    secrets:
+      SUITE_ID:
+        required: true
+        type: string
+      API_KEY:
+        required: true
+        type: string
+
+jobs:
+  ghost-inspector-run:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run test suite
+        run: |
+          curl "https://api.ghostinspector.com/v1/suites/${{ secrets.SUITE_ID }}/execute/?apiKey=${{ secrets.API_KEY }}" -m 1200
+      - name: Get suite result
+        shell: bash
+        run: |
+          response=$(curl "https://api.ghostinspector.com/v1/suites/${{ secrets.SUITE_ID }}/results/?apiKey=${{ secrets.API_KEY }}&count=1")
+          name=$(jq '.data[0].name' <<< $response )
+          result=$(jq '.data[0].passing' <<< $response)
+          if [[ $result == 'true' ]]; then
+            echo "Suite ${name} passing"
+            exit 0
+          fi
+          echo "Suite ${name} failing"
+          exit 1

--- a/README.md
+++ b/README.md
@@ -1,3 +1,48 @@
 # GovPress Workflow: Ghost Inspector
 
-A reusable workflow to run Ghost Inspector tests.
+A reusable workflow to run Ghost Inspector test suites. It take a Ghost Inspector test suite ID and API Key, and returns the status of that test suite.
+
+The primary intention is that this workflow will be used in production deployment PRs, to run the test suite on staging as part of the CI pipeline, but it could in theory be used in any scenario where we want to check the status of a test suite as part of CI.
+
+## Usage
+
+To use this in a repo, following the instructions for [calling a reusable workflow](https://docs.github.com/en/actions/using-workflows/reusing-workflows#calling-a-reusable-workflow), passing `SUITE_ID` and `API_KEY` as secrets. The values of those secrets could be stored e.g. as secrets at individual repo level.
+
+### Example usage
+
+This example would result in the test suite being run on each pull request event.
+
+In this example, the API key and suite ID are stored as repo-level secrets in the calling repo.
+
+```yml
+name: Run Ghost Inspector test suite
+
+on: [pull_request]
+
+jobs:
+
+  run-test-suite:
+    uses: dxw/govpress-workflow-ghost-inspector/.github/workflows/ghost-inspector.yml@v1
+    secrets:
+      API_KEY: ${{ secrets.GHOST_INSPECTOR_API_KEY }}
+      SUITE_ID: ${{ secrets.GHOST_INSPECTOR_TEST_SUITE_ID_STAGING }}
+```
+
+
+## Testing locally
+
+You can test the workflow locally using [act](https://github.com/nektos/act).
+
+Install act:
+
+```bash
+brew install act
+```
+
+Test the action (from the root directory of this repo)
+
+```bash
+act -j ghost-inspector-run -s API_KEY=[your-ghost-inspector-api-key] -s SUITE_ID=[a-ghost-inspector-suite-id]
+```
+
+If the test suite passes, the action should exit with a success code, otherwise it will exit with a failure code (including if the test suite does not exist).


### PR DESCRIPTION
This PR adds the workflow for running a GhostInspector test in a GitHub action, plus documentation.

The workflow has to be passed two secrets: a Ghost Inspector API Key and the Ghost Inspector Suite ID to be run. If you have a Ghost Inspector account, your API key can be found on your [account page](https://app.ghostinspector.com/account). When running tests as part of CI, we'll use the API key for the `dalmatian@dxw.com` account. Test suite IDs can be found in the URL when browsing the Ghost Inspector front-end: `https://app.ghostinspector.com/suites/[test-suite-id]`.

The workflow makes two CURL requests to the GhostInspector API: the first to run the requested test suite, and the second to get the result of that test suite run. If the test suite has passed, the workflow exists with a success code, if it has failed or does not exist, it exits with a failure code (which will cause the CI run to fail). 

See the README for full details of how this workflow could be called from a specific repo, and how to test it locally using [act](https://github.com/nektos/act).