### PR TITLE
Fix/do not specify secret type

### DIFF
--- a/.github/workflows/ghost-inspector.yml
+++ b/.github/workflows/ghost-inspector.yml
@@ -5,10 +5,8 @@ on:
     secrets:
       SUITE_ID:
         required: true
-        type: string
       API_KEY:
         required: true
-        type: string
 
 jobs:
   ghost-inspector-run:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on Keep a Changelog, and this project adheres to Semantic Versioning.
+
+## [1.0.1] - 2022-06-10
+
+### Amended
+- Does not specify types for secrets, as this is unsupported
+
+## [1.0.0] - 2022-06-09
+Initial release


### PR DESCRIPTION
This PR removes the type attribute on the two required secrets, as this is unsupported (see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onworkflow_callsecrets for supported attributes).

It also adds a CHANGELOG.