### PR TITLE
Count screenshot passes and failures in end result

### DIFF
--- a/.github/workflows/ghost-inspector.yml
+++ b/.github/workflows/ghost-inspector.yml
@@ -20,12 +20,15 @@ jobs:
         run: |
           response=$(curl "https://api.ghostinspector.com/v1/suites/${{ secrets.SUITE_ID }}/results/?apiKey=${{ secrets.API_KEY }}&count=1")
           name=$(jq '.data[0].name' <<< $response )
-          result=$(jq '.data[0].passing' <<< $response)
+          testResult=$(jq '.data[0].passing' <<< $response)
+          screenshotResult=$(jq '.data[0].screenshotComparePassing' <<< $response)  # Can be null.
           failingCount=$(jq '.data[0].countFailing' <<< $response)
           passingCount=$(jq '.data[0].countPassing' <<< $response)
-          if [[ $result == 'true' ]]; then
-            echo "Suite ${name} passing: ${passingCount} passed, 0 failed"
+          failingScreenshotCount=$(jq '.data[0].countScreenshotCompareFailing' <<< $response)
+          passingScreenshotCount=$(jq '.data[0].countScreenshotComparePassing' <<< $response)
+          if [[ $testResult == 'true' ]] && [[ $screenshotResult == 'true' || $screenshotResult == 'null' ]]; then
+            echo "Suite ${name} passing: ${passingCount} tests passed, ${passingScreenshotCount} screenshot comparisons passed, 0 tests/screenshots failed"
             exit 0
           fi
-          echo "Suite ${name} failing: ${passingCount} passed, ${failingCount} failed"
+          echo "Suite ${name} failing: ${passingCount} tests passed, ${passingScreenshotCount} screenshot comparisons passed, ${failingCount} tests failed, ${failingScreenshotCount} screenshot comparisons failed"
           exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog, and this project adheres to Semantic Versioning.
 
+## [1.1.0] - 2024-09-23
+
+### Amended
+- Workflow now only passes if both tests and screenshot comparisons pass
+
 ## [1.0.1] - 2022-06-10
 
 ### Amended

--- a/README.md
+++ b/README.md
@@ -45,4 +45,7 @@ Test the action (from the root directory of this repo)
 act -j ghost-inspector-run -s API_KEY=[your-ghost-inspector-api-key] -s SUITE_ID=[a-ghost-inspector-suite-id]
 ```
 
+Depending on the architecture of your local machine, you may need to pass
+`--container-architecture linux/amd64` as an argument to `act`.
+
 If the test suite passes, the action should exit with a success code, otherwise it will exit with a failure code (including if the test suite does not exist).


### PR DESCRIPTION
This workflow now only passes if _both_ tests and screenshot comparisons pass.

## Testing

1. Clone this repo and checkout this feature branch
2. We're only changing the part of the workflow that validates the test results, so comment out the lines in the workflow that run the suite, otherwise the workflow will timeout locally on some suites:
```yaml
      - name: Run test suite
        run: |
          curl "https://api.ghostinspector.com/v1/suites/${{ secrets.SUITE_ID }}/execute/?apiKey=${{ secrets.API_KEY }}" -m 1200
```
3. Choose some GhostInspector suites to test. Pick at least one suite with tests passing and screenshots failing and one with both tests and screenshots passing. The suite ID is in the URL or in the settings for the suite.
4. Follow the instructions in the [`README.md`](https://github.com/dxw/govpress-workflow-ghost-inspector/blob/main/README.md) to run the test suite. Note that you may need to add `--container-architecture linux/amd64` to the command line invocation of `act`, depending on what architecture your Mac has.
